### PR TITLE
update boot-profile.boot according to docs on boot wiki

### DIFF
--- a/boot-profile.boot
+++ b/boot-profile.boot
@@ -1,9 +1,9 @@
 (require 'boot.repl)
 
-(swap! boot.repl/*default-dependencies* conj
-       '[refactor-nrepl "2.3.0-SNAPSHOT"]
-       '[org.clojure/tools.nrepl "0.2.12-SNAPSHOT"]
-       '[cider/cider-nrepl "0.12.0-SNAPSHOT"])
+(swap! boot.repl/*default-dependencies*
+       concat '[[refactor-nrepl "2.3.0-SNAPSHOT"]
+                [org.clojure/tools.nrepl "0.2.12-SNAPSHOT"]
+                [cider/cider-nrepl "0.12.0-SNAPSHOT"]])
 
 (swap! boot.repl/*default-middleware*
        conj 'cider.nrepl/cider-middleware)
@@ -12,16 +12,18 @@
 (swap! boot.repl/*default-middleware* conj
        'refactor-nrepl.middleware/wrap-refactor)
 
-(set-env! :dependencies #(conj % '[spyscope "0.1.5"]))
-(require 'spyscope.core)
-(boot.core/load-data-readers!)
+;; (set-env! :dependencies #(conj % '[spyscope "0.1.5"]))
+;; (require 'spyscope.core)
+;; (boot.core/load-data-readers!)
 
-;; (deftask cider ""
-;;   []
-;;   (reset! boot.repl/*default-dependencies*
-;;           '[[org.clojure/tools.nrepl "0.2.12"]
-;;             [cider/cider-nrepl "0.10.0"]
-;;             [refactor-nrepl "2.0.0-SNAPSHOT"]])
-;;   (reset! boot.repl/*default-middleware*
-;;           ['cider.nrepl/cider-middleware
-;;            'refactor-nrepl.middleware/wrap-refactor]))
+(deftask cider "CIDER profile"
+  []
+  (require 'boot.repl)
+  (swap! @(resolve 'boot.repl/*default-dependencies*)
+         concat '[[refactor-nrepl "2.3.0-SNAPSHOT"]
+                  [org.clojure/tools.nrepl "0.2.12-SNAPSHOT"]
+                  [cider/cider-nrepl "0.12.0-SNAPSHOT"]])
+  (swap! @(resolve 'boot.repl/*default-middleware*)
+         concat '[cider.nrepl/cider-middleware
+                  refactor-nrepl.middleware/wrap-refactor])
+  identity)


### PR DESCRIPTION
* spyscope is producing the following warnings when running boot tasks:
  >Warning: version conflict detected: org.clojure/clojure version changes from 1.6.0 to 1.8.0
  >Warning: version conflict detected: clj-time version changes from 0.7.0 to 0.9.0
  >Warning: version conflict detected: joda-time version changes from 2.3 to 2.6
  
  Temporarily commented out its code.

* Updated the rest of the code according to the following wiki documentation:
  https://github.com/boot-clj/boot/wiki/Cider-REPL

* boot dev, boot repl and cider-jack-in work without any apparent errors.